### PR TITLE
Force sphinx version >= 3.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx>=3.0
 better-apidoc
 sphinx-autodoc-typehints
 sphinx-autorun


### PR DESCRIPTION
ReadTheDocs uses v1.8.5 even if sphinx-autodoc-typehints requires sphinx>=3.0. Why? No idea.